### PR TITLE
Make the type of builder to be a parameter of the config file

### DIFF
--- a/files/build_deploy.py
+++ b/files/build_deploy.py
@@ -49,6 +49,13 @@ parser.add_argument("config_file", help="yaml file for the builder config")
 args = parser.parse_args()
 
 
+builder_commands = {
+    'middleman': {
+        'build': ['bundle', 'exec', 'middleman' 'build', '--verbose']
+    }
+}
+
+
 def debug_print(message):
     if args.debug:
         print message
@@ -206,9 +213,9 @@ if not args.sync_only:
         notify_error('install', C.output)
 
     try:
-        syslog.syslog("Build of {}: bundle exec middleman build".format(name))
-        result = subprocess.check_output(['bundle', 'exec', 'middleman',
-                                          'build', '--verbose'])
+        command = builder_commands[config['builder']]
+        syslog.syslog("Build of {}: {}".format(name, ' '.join(command)))
+        result = subprocess.check_output(command)
     except subprocess.CalledProcessError, C:
         notify_error('build', C.output)
 

--- a/templates/builder.yml
+++ b/templates/builder.yml
@@ -1,4 +1,5 @@
 name: {{ name }}
+builder: 'middleman'
 notification:
 {% if irc_server %}
   irc:


### PR DESCRIPTION
For now, as I have no idea of what is needed for jekyll or
similar, I will just try to not hardcode more than needed.

I do not want to document it since there is nothing to change
for now.

Maybe we will have to extend the script to do handle more than
bundle install, maybe more than "install" and "build" step.
