### PR TITLE
Prune old branches

### DIFF
--- a/files/build_deploy.py
+++ b/files/build_deploy.py
@@ -186,6 +186,7 @@ syslog.syslog("Start the build of {}".format(name))
 os.chdir(checkout_dir)
 subprocess.call(['git', 'stash'])
 subprocess.call(['git', 'stash', 'clear'])
+subprocess.call(['git', 'remote', 'prune', 'origin'])
 subprocess.call(['git', 'pull', '--rebase'])
 
 if has_submodules(checkout_dir):


### PR DESCRIPTION
It was found on gluster.org infra that removing old branches cause
git pull --rebase to fail if there is no pruning done. So we
now have to do it by default, so this prevent future instance
of the breakage.
