### PR TITLE
Support running in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This will deploy the build of https://git.example.org/website.git by
 using rsync as rsync_user on www.example.org, copying in /var/www/html. If you do
 not provide it, then no deployment the default builder deployment method is used
 instead, if any. The OpenShift deployment has been removed as version 2 is EOL.
+It is also possible to only provide a rsync_location without the other parameters
+for a local sync.
 
 The script will not sync if build failed, and will not send email (that's on the
 TODO list, see end of the file). Nevertheless, failures caught by Cron can be
@@ -54,6 +56,8 @@ The role will rebuild the website on a regular basis, every 6h
 by default. This can be changed with the parameter `rebuild_interval`, which express
 the time between automated rebuild attempts if nothing changed, expressed in hours.
 
+This feature is disabled on containers.
+
 # Debug the build
 
 In order to debug a non working build, the easiest is to connect to the
@@ -73,6 +77,15 @@ submodule_commits: {}
 Then, the build script can be run with `/usr/local/bin/build_deploy.py -d -f -n ~/website_example_org.yml`,
 which would force a build (-f) without pushing (-n) with debug turned on (-d).
 
+This feature is disabled on containers.
+
+# Containers
+
+If running in a container this role will not create crontabs but instead build the website at once. You may
+use the rsync feature to locally install the resulting pages in the proper place. In this case the publishing
+space may need to be created in between the builder is setup and the website built, so you may set
+`builder_container_build_now` to False and use the `build` entrypoint manually when convenient.
+
 # Jenkins integration
 
 If you wish to use the role with a external system to trigger such as Jenkins, you will need to disable
@@ -90,3 +103,6 @@ While being already used in production, several options are missing
 - proper logging of error
 - handling automatically some errors (like rebuilding gems)
 - change the schedule of automated rebuild
+- make result directory available to subsequent roles to avoid
+  copying files when unnecessary
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,5 @@ irc_server: False
 # in hours
 rebuild_interval: 6
 external_trigger: False
+builder_container_build_now: True
+

--- a/molecule/_resources/playbook.yml
+++ b/molecule/_resources/playbook.yml
@@ -3,7 +3,7 @@
 - name: Install Web Builder
   hosts: ansible-test-builder
   tasks:
-    - name: Testing role
+    - name: "Testing role (host)"
       include_role:
         name: ansible-role-web_builder
       vars:
@@ -13,4 +13,10 @@
         rsync_server: ansible-test-web
         rsync_user: web_builder
         rsync_location: /var/www/www.example.com
+    - name: "Testing role (container)"
+      include_role:
+        name: ansible-role-web_builder
+      vars:
+        builder_name: testbuilder_container
+        builder_username: web_builder
 

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,0 +1,12 @@
+---
+
+- name: "Build now (container)"
+  vars:
+    builder_options: '-f -d'
+  block:
+    - name: "Build the website"
+      command: "{{ builder_command }}"
+      become_user: "{{ builder_username }}"
+      become: True
+      changed_when: True
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,7 @@
     dest: "{{ checkout_dir }}"
     version: "{{ git_version | default( 'HEAD' ) }}"
     force: yes   # needed because of submodules to avoid "Local modifications exist in repository"
+    umask: '0022'
   become: yes
   become_user: '{{ builder_username }}'
   become_method: 'su'
@@ -98,46 +99,20 @@
   set_fact:
     rsync_url: "nosync"
 
-- name: Compute RSYNC URL
+- name: "Compute RSYNC URL (remote)"
   set_fact:
     rsync_url: "{{ rsync_user }}@{{ rsync_server }}:{{ rsync_location }}"
-  when: rsync_server is defined and rsync_location is defined and rsync_user is defined
+  when: rsync_location is defined and rsync_server is defined and rsync_user is defined
+
+- name: "Compute RSYNC URL (local)"
+  set_fact:
+    rsync_url: "{{ rsync_location }}"
+  when: rsync_location is defined and rsync_server is undefined and rsync_user is undefined
 
 - name: Deploy yaml config for {{ builder_name }}
   template:
     dest: "/srv/builder/{{ builder_name }}.yml"
     src: builder.yml.j2
-
-- name: Add cron to build {{ builder_name }}
-  cron:
-    name: "build and deploy {{ builder_name }}"
-    job: "/usr/local/bin/build_deploy.py /srv/builder/{{ builder_name }}.yml"
-    user: "{{ builder_username }}"
-    state: "{% if external_trigger %}absent{% else %}present{% endif %}"
-
-- name: Setup cron email
-  cronvar:
-    user: "{{ builder_username }}"
-    name: MAILTO
-    value: "{{ cron_error_email }}"
-  when: cron_error_email is defined
-
-# needed to detect package manager (at least) on the other host
-# without cache or if it expired, the play would fail
-- name: Get facts for the other side
-  setup:
-  delegate_to: "{{ rsync_server }}"
-  delegate_facts: True
-  when: rsync_url != 'nosync' and rsync_server not in play_hosts
-
-# TODO add ip restriction
-- name: Copy the key on the other side
-  authorized_key:
-    key: "{{ result.ssh_public_key }}"
-    key_options: "{{ sync_ssh_key_options }}"
-    user: "{{ rsync_user }}"
-  delegate_to: "{{ rsync_server }}"
-  when: rsync_url != 'nosync'
 
 - name: Install Rsync
   package:
@@ -145,22 +120,11 @@
     state: present
   when: rsync_url != 'nosync'
 
-- name: Install Rsync on the other side
-  package:
-    name: "{{ rsync_package }}"
-    state: present
-  delegate_to: "{{ rsync_server }}"
-  when: rsync_url != 'nosync'
+- name: "Schedule build and sync"
+  include_tasks: schedule_build_and_sync.yml
+  when: ansible_env.container is undefined
 
-- name: Create SSH config for rsync sync
-  blockinfile:
-    path: /srv/builder/.ssh/config
-    owner: "{{ builder_username }}"
-    group: "{{ builder_username }}"
-    block: |
-      Match Host {{ rsync_server }} User {{ rsync_user }}
-          IdentityFile /srv/builder/.ssh/{{ builder_name }}_id.rsa
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ builder_name }}"
-    create: true
-  when: rsync_url != 'nosync'
+- name: "Build now (container)"
+  include_tasks: build.yml
+  when: ansible_env.container is defined and builder_container_build_now|bool
 

--- a/tasks/schedule_build_and_sync.yml
+++ b/tasks/schedule_build_and_sync.yml
@@ -1,0 +1,52 @@
+---
+
+- name: Add cron to build {{ builder_name }}
+  cron:
+    name: "build and deploy {{ builder_name }}"
+    job: "{{ builder_command }}"
+    user: "{{ builder_username }}"
+    state: "{% if external_trigger %}absent{% else %}present{% endif %}"
+
+- name: Setup cron email
+  cronvar:
+    user: "{{ builder_username }}"
+    name: MAILTO
+    value: "{{ cron_error_email }}"
+  when: cron_error_email is defined
+
+# needed to detect package manager (at least) on the other host
+# without cache or if it expired, the play would fail
+- name: Get facts for the other side
+  setup:
+  delegate_to: "{{ rsync_server }}"
+  delegate_facts: True
+  when: rsync_url != 'nosync' and rsync_server not in play_hosts
+
+# TODO add ip restriction
+- name: Copy the key on the other side
+  authorized_key:
+    key: "{{ result.ssh_public_key }}"
+    key_options: "{{ sync_ssh_key_options }}"
+    user: "{{ rsync_user }}"
+  delegate_to: "{{ rsync_server }}"
+  when: rsync_url != 'nosync'
+
+- name: Install Rsync on the other side
+  package:
+    name: "{{ rsync_package }}"
+    state: present
+  delegate_to: "{{ rsync_server }}"
+  when: rsync_url != 'nosync'
+
+- name: Create SSH config for rsync sync
+  blockinfile:
+    path: /srv/builder/.ssh/config
+    owner: "{{ builder_username }}"
+    group: "{{ builder_username }}"
+    block: |
+      Match Host {{ rsync_server }} User {{ rsync_user }}
+          IdentityFile /srv/builder/.ssh/{{ builder_name }}_id.rsa
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ builder_name }}"
+    create: true
+  when: rsync_url != 'nosync'
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,4 +7,5 @@ builder_repo:
     writable_subdirs:
       - themes
 sync_ssh_key_options: "command=\"rsync --server -vlogtrze.isf --delete-after --omit-dir-times . {{ rsync_location }}\",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty"
+builder_command: "/usr/local/bin/build_deploy.py {{ builder_options | default('') }} /srv/builder/{{ builder_name }}.yml"
 


### PR DESCRIPTION
Basically skip all the build scheduling and run the build in place.

Also allows to sync locally; the consuming service may need to be
installed in between the builder is setup and the website is build, you
may disable building and trigger it yourself later.

In case you wish to use the builder result directory directly, the
permissions have been corrected. This directory path has to be
recalculated outside this role at the moment.